### PR TITLE
Make corresponding mixin for LTI roles being required.  Remove GroupRequ...

### DIFF
--- a/django_auth_lti/mixins.py
+++ b/django_auth_lti/mixins.py
@@ -1,37 +1,41 @@
 from django.core.urlresolvers import reverse_lazy
-from django.contrib.auth.decorators import login_required
-from django.utils.decorators import method_decorator
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import redirect
 from django.core.exceptions import PermissionDenied
+from braces.views import LoginRequiredMixin
 
 
-class LoginRequiredMixin(object):
-    @method_decorator(login_required)
-    def dispatch(self, request, *args, **kwargs):
-        return super(LoginRequiredMixin, self).dispatch(request, *args, **kwargs)
-
-
-class GroupMembershipRequiredMixin(LoginRequiredMixin):
-    allowed_groups = None
+class LTIRoleRestrictionMixin(object):
+    allowed_roles = None
     redirect_url = reverse_lazy('not_authorized')
     raise_exception = False
 
     def dispatch(self, request, *args, **kwargs):
-        if self.allowed_groups is None:
+        if self.allowed_roles is None:
             raise ImproperlyConfigured(
-                "'GroupMembershipRequiredMixin' requires "
-                "'allowed_groups' attribute to be set.")
-        if not isinstance(self.allowed_groups, (list, tuple)):
-            allowed = (self.allowed_groups, )
-        else:
-            allowed = self.allowed_groups
+                "'LTIRoleRestrictionMixin' requires "
+                "'allowed_roles' attribute to be set.")
 
-        group_ids = request.session.get('USER_GROUPS', [])
-        if set(allowed) & set(group_ids):
-            return super(GroupMembershipRequiredMixin, self).dispatch(request, *args, **kwargs)
+        # Handle allowed roles as either a list or a single string
+        if not isinstance(self.allowed_roles, (list, tuple)):
+            allowed = (self.allowed_roles, )
+        else:
+            allowed = self.allowed_roles
+
+        lti_params = request.session.get('LTI_LAUNCH', None)
+        user_roles = lti_params.get('roles', [])
+
+        if set(allowed) & set(user_roles):
+            return super(LTIRoleRestrictionMixin, self).dispatch(request, *args, **kwargs)
 
         if self.raise_exception:
             raise PermissionDenied
 
         return redirect(self.redirect_url)
+
+
+class LTIRoleRequiredMixin(LoginRequiredMixin, LTIRoleRestrictionMixin):
+    """
+    Mixin is a shortcut to use both LoginRequiredMixin and LTIRoleRestrictionMixin
+    """
+    pass

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-auth-lti',
-    version='0.4',
+    version='0.5',
     packages=find_packages(),
     include_package_data=True,
     license='TBD License',  # example license
@@ -34,6 +34,7 @@ setup(
         "Django>=1.6",
         "django-filter==0.7",
         "ims-lti-py==0.6",
+        "django-braces==1.3.1",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
...iredMixin and LoginRequiredMixin since the former is not used in LTI requests and neither was being used currently anyway.  Require django_braces with this library and use it's LoginRequiredMixin instead.  Update version.
