### PR TITLE
Fixes errant print statement in LTIAuthBackend

### DIFF
--- a/django_auth_lti/backends.py
+++ b/django_auth_lti/backends.py
@@ -63,8 +63,6 @@ class LTIAuthBackend(ModelBackend):
 
         logger.info("done checking the signature")
 
-        print tool_provider.oauth_timestamp
-
         logger.info("about to check the timestamp: %d" % int(tool_provider.oauth_timestamp))
         if time() - int(tool_provider.oauth_timestamp) > 60 * 60:
             logger.error("OAuth timestamp is too old.")


### PR DESCRIPTION
This PR removes a debugging `print` statement from `LTIAuthBackend.authenticate()`

One of our LTI tools was raising a _500 Internal Server_ while running in CGI mode on sites.fas.harvard.edu and the apache logs showed this error: `malformed header from script. Bad header=1407779241: index.py`. I traced it down to this print statement that just outputs the oauth timestamp. Since it looks like the timestamp is being logged anyway, I went ahead and removed the print statement.

Just thought I'd send this change upstream. Thoughts?
