### PR TITLE
Feature/settings error

### DIFF
--- a/django_auth_lti/backends.py
+++ b/django_auth_lti/backends.py
@@ -38,6 +38,10 @@ class LTIAuthBackend(ModelBackend):
             logger.error("Request doesn't contain an oauth_consumer_key; can't continue.")
             return None
 
+        if not oauth_creds:
+            logger.error("Missing LTI_OAUTH_CREDENTIALS in settings")
+            raise PermissionDenied
+
         secret = oauth_creds.get(request_key, None)
 
         if secret is None:


### PR DESCRIPTION
adds error check for when `settings.LTI_OAUTH_CREDENTIALS` is `None` or `{}`, which is possible due to improperly configured ENV_SETTINGS in a project