### PR TITLE
Don't store LTI_OAUTH_SETTINGS during module load so that functional tes...

### DIFF
--- a/django_auth_lti/backends.py
+++ b/django_auth_lti/backends.py
@@ -10,9 +10,6 @@ logger = logging.getLogger(__name__)
 
 from django.conf import settings
 
-# get credentials from config
-oauth_creds = settings.LTI_OAUTH_CREDENTIALS
-
 
 class LTIAuthBackend(ModelBackend):
 
@@ -38,11 +35,11 @@ class LTIAuthBackend(ModelBackend):
             logger.error("Request doesn't contain an oauth_consumer_key; can't continue.")
             return None
 
-        if not oauth_creds:
+        if not settings.LTI_OAUTH_CREDENTIALS:
             logger.error("Missing LTI_OAUTH_CREDENTIALS in settings")
             raise PermissionDenied
 
-        secret = oauth_creds.get(request_key, None)
+        secret = settings.LTI_OAUTH_CREDENTIALS.get(request_key)
 
         if secret is None:
             logger.error("Could not get a secret for key %s" % request_key)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-auth-lti',
-    version='0.8',
+    version='1.0',
     packages=['django_auth_lti'],
     include_package_data=True,
     license='TBD License',  # example license


### PR DESCRIPTION
...ts can override settings on each tests run - the auth_lti backend is imported once as an AUTHENTICATION_BACKEND during project load so storing the settings at the top of the module prevents overriding of this setting during authentication.  Up version to 1.0 (current Github release is at 0.9, so this is another minor bump).