### PR TITLE
example commit to show use of proposed ims_lti_py changes

### DIFF
--- a/examples/lti_request_validator.py
+++ b/examples/lti_request_validator.py
@@ -1,0 +1,51 @@
+
+from oauthlib.oauth1 import RequestValidator
+from oauthlib.common import to_unicode
+from django.conf import settings
+from models import Nonce
+import time
+
+NONCE_TTL = 3600.0
+
+class LTIRequestValidator(RequestValidator):
+
+    enforce_ssl = False
+
+    dummy_secret = 'secret'
+    dummy_client = (u'dummy_'
+        '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae')
+
+    def check_client_key(self, key):
+        # any non-empty string is OK as a client key
+        return len(key) > 0
+
+    def check_nonce(self, nonce):
+        # any non-empty string is OK as a nonce
+        return len(nonce) > 0
+
+    def validate_client_key(self, client_key, request):
+        return client_key in settings.LTI_OAUTH_CREDENTIALS
+
+    def validate_timestamp_and_nonce(self, client_key, timestamp, nonce,
+                                     request, request_token=None,
+                                     access_token=None):
+        now = time.time()
+        try:
+            nonce_rec = Nonce.objects.get(nonce=nonce)
+            last_seen = nonce_rec.timestamp
+            if last_seen + NONCE_TTL < now:
+                nonce_rec.timestamp = now
+                nonce_rec.save()
+                return True
+            else:
+                return False
+        except Nonce.DoesNotExist:
+            n = Nonce(nonce=nonce)
+            n.save()
+            return True
+
+    def get_client_secret(self, client_key, request):
+        secret = settings.LTI_OAUTH_CREDENTIALS.get(client_key, self.dummy_secret)
+        # make sure secret val is unicode
+        return to_unicode(secret)
+

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     install_requires=[
         "Django>=1.6",
-        "ims-lti-py==0.6",
+        "ims-lti-py",
         "django-braces==1.3.1",
     ],
     tests_require=[


### PR DESCRIPTION
I've recently done a major reworking of the ims_lti_py library and submitted a pull request here: https://github.com/tophatmonocle/ims_lti_py/pull/20. I tried to preserve the public api of the module as much as possible, but there's mucho structural changes under the hood, as well as a rewrite of at least 60% of the test suite. I've also created an github issue asking WTF is the status of the project: https://github.com/tophatmonocle/ims_lti_py/issues/19

This is a quick PR to show how django-auth-lti would need to be adapted to make use of the updated ims_lti_py. Just looking for comments/feedback on both PRs at the moment. I'm using django-auth-lti in a grand total of one LTI tool, so my use cases and experience are pretty limited.

The major change to django-auth-lti is that the tool provider's `is_valid_reqeust()` method now requires an instance of an oauthlib.oauth1 RequestValidator. I implemented something simple in `validator.py`, but it could be done in other ways. (For instance, the LTIAuthBackend could subclass RequestValidator and pass itself in.)

cc: @rascalking @douglashall @djcp @elliottyates @cmurtaugh @bermudezjd 
