### PR TITLE
Empty request fix

### DIFF
--- a/django_auth_lti/patch_reverse.py
+++ b/django_auth_lti/patch_reverse.py
@@ -25,7 +25,8 @@ def reverse(*args, **kwargs):
     exclude_resource_link_id = kwargs.pop('exclude_resource_link_id', False)
 
     url = django_reverse(*args, **kwargs)
-    if not exclude_resource_link_id:
+    resource_link_id = request.LTI.get('resource_link_id')
+    if not exclude_resource_link_id and resource_link_id is not None:
         # Append resource_link_id query param if exclude_resource_link_id kwarg was not passed or is False
         parsed = urlparse(url)
         query = parse_qs(parsed.query)

--- a/django_auth_lti/patch_reverse.py
+++ b/django_auth_lti/patch_reverse.py
@@ -25,13 +25,20 @@ def reverse(*args, **kwargs):
     exclude_resource_link_id = kwargs.pop('exclude_resource_link_id', False)
 
     url = django_reverse(*args, **kwargs)
-    resource_link_id = request.LTI.get('resource_link_id')
-    if not exclude_resource_link_id and resource_link_id is not None:
+
+    if request:
+        resource_link_id = request.get('LTI', {}).get('resource_link_id')
+    else:
+        resource_link_id = None
+
+    if not exclude_resource_link_id and resource_link_id:
         # Append resource_link_id query param if exclude_resource_link_id kwarg was not passed or is False
         parsed = urlparse(url)
         query = parse_qs(parsed.query)
         if 'resource_link_id' not in query.keys():
-            query['resource_link_id'] = request.LTI.get('resource_link_id')
+            if resource_link_id:
+                query['resource_link_id'] = resource_link_id
+
             url = urlunparse(
                 (parsed.scheme, parsed.netloc, parsed.path, parsed.params, urlencode(query), parsed.fragment)
             )


### PR DESCRIPTION
Sometimes the request is None (I came across such an issue with the Django Debug Toolbar), so the reverse method should be able to handle such a case.

I'm not sure this is the most elegant solution, but it fixed the issue for me. If no request, can we just return url straight from the output of django_reverse from line 27?