### PR TITLE
Fix append_resource_link_id

### DIFF
--- a/django_auth_lti/static/django_auth_lti/js/resource_link_id.js
+++ b/django_auth_lti/static/django_auth_lti/js/resource_link_id.js
@@ -3,6 +3,7 @@ window.globals.append_resource_link_id = function(url){
         var url_separator = (url.match(/\?/)) ? '&' : '?';
         return url + url_separator + 'resource_link_id=' + window.globals.RESOURCE_LINK_ID;
     }
+    return url;
 };
 
 $(document).ajaxSend(function(event, jqxhr, settings){

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-auth-lti',
-    version='1.2.2',
+    version='1.2.3',
     packages=['django_auth_lti'],
     include_package_data=True,
     license='TBD License',  # example license


### PR DESCRIPTION
Fixes a bug that caused an undefined url when appending resource link ID to a URL string that already has a resource link ID param.