### PR TITLE
Sprint 45 TLT-2211 Catch, log, and handle lti oauth validation errors better

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Django>=1.6",
         "ims-lti-py==0.6",
         "django-braces==1.3.1",
+        "oauth2==1.9.0.post1", # to catch errors uncaught by ims-lti-py
     ],
     tests_require=[
         'mock',


### PR DESCRIPTION
In this case, better means explicitly catching oauth errors (since ims_lti_py doesn't catch-and-wrap them).  Now we can log the error alongside the post params, to help us troubleshoot from the prod logs, and we can return a permission denied error, so the user gets an unauthorized page instead of a 500 internal sever error.