### PR TITLE
Added the text attribute to the LTI_LAUNCH data.

### DIFF
--- a/django_auth_lti/middleware.py
+++ b/django_auth_lti/middleware.py
@@ -98,6 +98,7 @@ class LTIAuthMiddleware(object):
                     'tool_consumer_instance_url': request.POST.get('tool_consumer_instance_url', None),
                     'user_id': request.POST.get('user_id', None),
                     'user_image': request.POST.get('user_image', None),
+                    'text': request.POST.get('text', None),
                 }
                 # If a custom role key is defined in project, merge into existing role list
                 if hasattr(settings, 'LTI_CUSTOM_ROLE_KEY'):

--- a/django_auth_lti/middleware_patched.py
+++ b/django_auth_lti/middleware_patched.py
@@ -110,6 +110,7 @@ class MultiLTILaunchAuthMiddleware(object):
                     'tool_consumer_instance_url': request.POST.get('tool_consumer_instance_url', None),
                     'user_id': request.POST.get('user_id', None),
                     'user_image': request.POST.get('user_image', None),
+                    'text': request.POST.get('text', None),
                 }
                 # If a custom role key is defined in project, merge into existing role list
                 if hasattr(settings, 'LTI_CUSTOM_ROLE_KEY'):

--- a/django_auth_lti/models.py
+++ b/django_auth_lti/models.py
@@ -1,1 +1,17 @@
-# Add models here
+from __future__ import unicode_literals
+
+from django.db import models
+import uuid
+
+def generate_strong_secret():
+    return uuid.uuid4().hex
+
+class LTIOauthCredentials(models.Model):
+    key = models.CharField(max_length=255, unique=True)
+    secret = models.CharField(max_length=255, unique=True, default=generate_strong_secret)
+    enabled = models.BooleanField(default=True)
+
+    org_name = models.CharField(max_length=255)
+    org_contact_email = models.EmailField()
+    org_contact_firstname = models.CharField(max_length=255)
+    org_contact_lastname = models.CharField(max_length=255)

--- a/django_auth_lti/patch_reverse.py
+++ b/django_auth_lti/patch_reverse.py
@@ -28,9 +28,19 @@ def reverse(*args, **kwargs):
     # Check if this app is in the RESOURCE_LINK_ID_BLACKLIST in the main settings. If it is then dont pass
     # resource_link_id as a param.
     if not exclude_resource_link_id:
-        blacklist = settings.get('RESOURCE_LINK_ID_BLACKLIST', [])
-        if request.resolver_match.app_name in blacklist:
+        blacklist = getattr(settings, 'RESOURCE_LINK_ID_BLACKLIST', [])
+        viewname = args[0]
+        if viewname in blacklist:
             exclude_resource_link_id = True
+        else:
+            try:
+                namespace, viewname = viewname.split(':')
+                if '{}:*'.format(namespace) in blacklist:
+                    # Exclude the whole namespace
+                    exclude_resource_link_id = True
+            except ValueError:
+                # No namespace, just ignore.
+                pass
 
     url = django_reverse(*args, **kwargs)
     if not exclude_resource_link_id:

--- a/django_auth_lti/patch_reverse.py
+++ b/django_auth_lti/patch_reverse.py
@@ -5,6 +5,7 @@ from urlparse import urlparse, urlunparse, parse_qs
 from urllib import urlencode
 
 from django.core import urlresolvers
+from django.conf import settings
 
 from .thread_local import get_current_request
 
@@ -23,6 +24,13 @@ def reverse(*args, **kwargs):
 
     # Check for custom exclude_resource_link_id kwarg and remove it before passing kwargs to django reverse
     exclude_resource_link_id = kwargs.pop('exclude_resource_link_id', False)
+
+    # Check if this app is in the RESOURCE_LINK_ID_BLACKLIST in the main settings. If it is then dont pass
+    # resource_link_id as a param.
+    if not exclude_resource_link_id:
+        blacklist = settings.get('RESOURCE_LINK_ID_BLACKLIST', [])
+        if request.resolver_match.app_name in blacklist:
+            exclude_resource_link_id = True
 
     url = django_reverse(*args, **kwargs)
     if not exclude_resource_link_id:


### PR DESCRIPTION
The text attribute is passed by (at least) Canvas when the LTI tool is launched from the RCE and text has been selected. If text has been selected in the RCE and the user expects the returned link to be applied to the selected text this is the only way to get the selected text.
