### PR TITLE
Add Django 1.10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ django_auth_lti is a package that provides Django authentication middleware and 
 
 To use LTI authentication with a Django app, edit settings.py as follows:
 
-* add 'django_auth_lti.middleware_patched.MultiLTILaunchAuthMiddleware' to your MIDDLEWARE_CLASSES, making sure that it appears AFTER 'django.contrib.auth.middleware.AuthenticationMiddleware'
+* add 'django_auth_lti.middleware_patched.MultiLTILaunchAuthMiddleware' to your MIDDLEWARE (Django >= 1.10) or MIDDLEWARE_CLASSES (Django < 1.10), making sure that it appears AFTER 'django.contrib.auth.middleware.AuthenticationMiddleware'
 
 * add 'django_auth_lti.backends.LTIAuthBackend' to your BACKEND_CLASSES
 

--- a/django_auth_lti/middleware.py
+++ b/django_auth_lti/middleware.py
@@ -7,13 +7,18 @@ from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    MiddlewareMixin = object
+
 from timer import Timer
 
 
 logger = logging.getLogger(__name__)
 
 
-class LTIAuthMiddleware(object):
+class LTIAuthMiddleware(MiddlewareMixin):
     """
     Middleware for authenticating users via an LTI launch URL.
 

--- a/django_auth_lti/middleware_patched.py
+++ b/django_auth_lti/middleware_patched.py
@@ -8,6 +8,11 @@ from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    MiddlewareMixin = object
+
 from timer import Timer
 
 from .thread_local import set_current_request
@@ -16,7 +21,7 @@ from .thread_local import set_current_request
 logger = logging.getLogger(__name__)
 
 
-class MultiLTILaunchAuthMiddleware(object):
+class MultiLTILaunchAuthMiddleware(MiddlewareMixin):
     """
     Middleware for authenticating users via an LTI launch URL.
 


### PR DESCRIPTION
Django 1.10 added a [new style of middleware](https://docs.djangoproject.com/en/1.10/releases/1.10/#new-style-middleware) that's incompatible with older versions.

[`django.utils.deprecation.MiddlewareMixin`](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#django.utils.deprecation.MiddlewareMixin) was also added to easily convert old-style middleware.
