### PR TITLE
Feature/django1 10 monkeypatching fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 *.egg-info
 *.egg
 .idea
+.tox/
+.eggs/

--- a/django_auth_lti/patch_reverse.py
+++ b/django_auth_lti/patch_reverse.py
@@ -8,8 +8,6 @@ from django.core import urlresolvers
 
 from .thread_local import get_current_request
 
-logger = logging.getLogger(__name__)
-
 django_reverse = None
 
 

--- a/django_auth_lti/patch_reverse.py
+++ b/django_auth_lti/patch_reverse.py
@@ -1,13 +1,19 @@
 """
 Monkey-patch django.core.urlresolvers.reverse to add resource_link_id to all URLs
 """
+import logging
 from urlparse import urlparse, urlunparse, parse_qs
 from urllib import urlencode
 
-from django.core import urlresolvers
+# Django 1.10 moved urlresolvers into django.urls package
+try:
+    from django import urls as urlresolvers
+except ImportError:
+    from django.core import urlresolvers
 
 from .thread_local import get_current_request
 
+logger = logging.getLogger(__name__)
 
 django_reverse = None
 
@@ -19,6 +25,7 @@ def reverse(*args, **kwargs):
     :param kwargs['exclude_resource_link_id']: Do not add the resource link id as a query parameter
     :returns Django named url
     """
+    logger.debug("inside custom reverse function!")
     request = get_current_request()
 
     # Check for custom exclude_resource_link_id kwarg and remove it before passing kwargs to django reverse
@@ -39,10 +46,11 @@ def reverse(*args, **kwargs):
 
 def patch_reverse():
     """
-    Monkey-patches the django.core.urlresolvers.reverse function. Will not patch twice.
+    Monkey-patches the reverse function. Will not patch twice.
     """
     global django_reverse
     if urlresolvers.reverse is not reverse:
+        logger.debug("inside patch_reverse where urlresolvers.reverse != reverse")
         django_reverse = urlresolvers.reverse
         urlresolvers.reverse = reverse
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
+import os
+import sys
 
+import django
 from django.conf import settings
+from django.test.utils import get_runner
 
-
-def runtests():
-    settings.configure(
-        # App-specific setttings here
-    )
-    # settings must be configured for this import to work
-    from django.test.runner import DiscoverRunner
-    DiscoverRunner(interactive=False, failfast=False).run_tests(['django_auth_lti'])
-
-if __name__ == '__main__':
-    runtests()
+if __name__ == "__main__":
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.test_settings'
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(["tests"])
+    sys.exit(bool(failures))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-auth-lti',
-    version='1.2.6',
+    version='1.2.7',
     packages=['django_auth_lti'],
     include_package_data=True,
     license='TBD License',  # example license
@@ -33,7 +33,7 @@ setup(
         "Django>=1.6",
         "ims-lti-py==0.6",
         "django-braces==1.3.1",
-        "oauth2==1.9.0.post1", # to catch errors uncaught by ims-lti-py
+        "oauth2==1.9.0.post1",  # to catch errors uncaught by ims-lti-py
     ],
     tests_require=[
         'mock',

--- a/tests/test_lti_auth_middleware.py
+++ b/tests/test_lti_auth_middleware.py
@@ -3,7 +3,7 @@ import mock
 from mock import patch
 from django.test import RequestFactory
 from django.contrib.auth import models
-from django_auth_lti.middleware_patched import MultiLTILaunchAuthMiddleware
+from django_auth_lti.middleware import LTIAuthMiddleware
 
 
 @patch('django_auth_lti.middleware.logger')
@@ -11,7 +11,7 @@ class TestLTIAuthMiddleware(unittest.TestCase):
     longMessage = True
 
     def setUp(self):
-        self.mw = MultiLTILaunchAuthMiddleware()
+        self.mw = LTIAuthMiddleware()
 
     def build_lti_launch_request(self, post_data):
         """

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,31 @@
+import os
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+SECRET_KEY = 'fake-key'
+
+INSTALLED_APPS = [
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'django_auth_lti',
+]
+
+ROOT_URLCONF = 'tests.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,8 +14,6 @@ INSTALLED_APPS = [
     'django_auth_lti',
 ]
 
-ROOT_URLCONF = 'tests.urls'
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,0 +1,36 @@
+from unittest import TestCase
+from mock import MagicMock
+from django_auth_lti.verification import is_allowed
+from django.core.exceptions import ImproperlyConfigured, PermissionDenied
+
+class TestVerification(TestCase):
+    
+    def test_is_allowed_success(self):
+        request = MagicMock(LTI={"roles": ["admin"]})
+        allowed_roles = ["admin", "student"]
+        user_is_allowed = is_allowed(request, allowed_roles, False)
+        self.assertTrue(user_is_allowed)
+    
+    def test_is_allowed_success_one_role(self):
+        request = MagicMock(LTI={"roles": ["admin"]})
+        allowed_roles = "admin"
+        user_is_allowed = is_allowed(request, allowed_roles, False)
+        self.assertTrue(user_is_allowed)
+    
+    def test_is_allowed_failure(self):
+        request = MagicMock(LTI={"roles":[]})
+        allowed_roles = ["admin", "student"]
+        user_is_allowed = is_allowed(request, allowed_roles, False)
+        self.assertFalse(user_is_allowed)
+    
+    def test_is_allowed_failure_one_role(self):
+        request = MagicMock(LTI={"roles":[]})
+        allowed_roles = "admin"
+        user_is_allowed = is_allowed(request, allowed_roles, False)
+        self.assertFalse(user_is_allowed)
+    
+    def test_is_allowed_exception(self):
+        request = MagicMock(LTI={"roles":["TF"]})
+        allowed_roles = ["admin", "student"]
+        self.assertRaises(PermissionDenied, is_allowed,
+                          request, allowed_roles, True)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,0 @@
-# from django.conf.urls import url
-
-urlpatterns = [
-    #  url(r'^admin/', admin.site.urls),
-]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,5 @@
+# from django.conf.urls import url
+
+urlpatterns = [
+    #  url(r'^admin/', admin.site.urls),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist =
+    py27-django{18,19,110}
+[testenv]
+deps =
+    py27: mock
+    django18: Django >= 1.8, < 1.9
+    django19: Django >= 1.9, < 1.10
+    django110: Django >= 1.10, < 1.11
+commands = python run_tests.py


### PR DESCRIPTION
This PR updates the `patch_reverse` module, used by MultiLTILaunchMiddleware, to be compatible with Django 1.10.  In prior verisons of Django, the `reverse` method was located within the `urlresolvers` module within `django.core`.  In 1.10+, there is a new `urls` module which imports `reverse` from a sub-module.  We need to patch that inclusion, as well as the import of `reverse` within `django.shortcuts`.

This PR also splits out the test cases for the reusable application into a `tests` module outside of the application package and introduces `tox` to make testing across Django versions easier.

@sapnamysore 
@cmurtaugh 