### PR TITLE
Hotfix/patch reverse import

### DIFF
--- a/django_auth_lti/patch_reverse.py
+++ b/django_auth_lti/patch_reverse.py
@@ -56,11 +56,9 @@ def patch_reverse():
         # module appears to be loaded before middleware so we need to
         # retroactively patch that `reverse` reference as well.
         try:
-            import django
-            from django import urls
-
+            from django import urls, shortcuts
             urls.reverse = reverse
-            django.shortcuts.reverse = reverse
+            shortcuts.reverse = reverse
         except ImportError:
             pass
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-auth-lti',
-    version='1.2.7',
+    version='1.2.8',
     packages=['django_auth_lti'],
     include_package_data=True,
     license='TBD License',  # example license


### PR DESCRIPTION
Update the way that the `reverse` function from `django.shortcuts` is getting imported to work in the context of a wsgi server load.  This fix gets around a module import error that was occurring when trying to start a containing project with Gunicorn.