### PR TITLE
Fix type error when transitioning old tools to use patched middleware

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,18 @@
+from django.test import RequestFactory
+from django.contrib.auth import models
+import mock
+
+def build_lti_launch_request(post_data):
+    """
+    Utility method that builds a fake lti launch request with custom data.
+    """
+    # Add message type to post data
+    post_data.update(lti_message_type='basic-lti-launch-request')
+    # Add resource_link_id to post data
+    if 'resource_link_id' not in post_data:
+        post_data.update(resource_link_id='d202fb112a14f27107149ed874bf630aa8e029a5')
+
+    request = RequestFactory().post('/fake/lti/launch', post_data)
+    request.user = mock.Mock(name='User', spec=models.User)
+    request.session = {}
+    return request

--- a/tests/test_lti_auth_middleware.py
+++ b/tests/test_lti_auth_middleware.py
@@ -1,9 +1,7 @@
 import unittest
-import mock
 from mock import patch
-from django.test import RequestFactory
-from django.contrib.auth import models
 from django_auth_lti.middleware import LTIAuthMiddleware
+import helpers
 
 
 @patch('django_auth_lti.middleware.logger')
@@ -14,18 +12,7 @@ class TestLTIAuthMiddleware(unittest.TestCase):
         self.mw = LTIAuthMiddleware()
 
     def build_lti_launch_request(self, post_data):
-        """
-        Utility method that builds a fake lti launch request with custom data.
-        """
-        # Add message type to post data
-        post_data.update(lti_message_type='basic-lti-launch-request')
-        # Add resource_link_id to post data
-        post_data.update(resource_link_id='d202fb112a14f27107149ed874bf630aa8e029a5')
-
-        request = RequestFactory().post('/fake/lti/launch', post_data)
-        request.user = mock.Mock(name='User', spec=models.User)
-        request.session = {}
-        return request
+        return helpers.build_lti_launch_request(post_data)
 
     @patch('django_auth_lti.middleware.auth')
     def test_roles_merged_with_custom_roles(self, mock_auth, mock_logger):

--- a/tests/test_lti_auth_middleware_patched.py
+++ b/tests/test_lti_auth_middleware_patched.py
@@ -56,5 +56,3 @@ class TestLTIAuthMiddleware(unittest.TestCase):
         request.session = dict(LTI_LAUNCH=lti_launch)
         self.mw.process_request(request)
         self.assertIsInstance(request.session['LTI_LAUNCH'], OrderedDict)
-
-        #or not isinstance(lti_launches, OrderedDict)

--- a/tests/test_lti_auth_middleware_patched.py
+++ b/tests/test_lti_auth_middleware_patched.py
@@ -6,11 +6,6 @@ from django.test import TestCase, override_settings
 import helpers
 import logging
 
-logger = logging.getLogger('django_auth_lti.middleware_patched')
-logger.setLevel(logging.DEBUG)
-ch = logging.StreamHandler()
-logger.addHandler(ch)
-
 LTI_AUTH_MAX_LAUNCHES=3
 
 @patch('django_auth_lti.middleware.logger')

--- a/tests/test_lti_auth_middleware_patched.py
+++ b/tests/test_lti_auth_middleware_patched.py
@@ -1,0 +1,60 @@
+import unittest
+from collections import OrderedDict
+from mock import patch
+from django_auth_lti.middleware_patched import MultiLTILaunchAuthMiddleware
+from django.test import TestCase, override_settings
+import helpers
+import logging
+
+logger = logging.getLogger('django_auth_lti.middleware_patched')
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+logger.addHandler(ch)
+
+LTI_AUTH_MAX_LAUNCHES=3
+
+@patch('django_auth_lti.middleware.logger')
+class TestLTIAuthMiddleware(unittest.TestCase):
+    longMessage = True
+
+    def setUp(self):
+        self.mw = MultiLTILaunchAuthMiddleware()
+
+    def build_lti_launch_request(self, post_data):
+        return helpers.build_lti_launch_request(post_data)
+
+    @override_settings(LTI_AUTH_MAX_LAUNCHES=LTI_AUTH_MAX_LAUNCHES)
+    @patch('django_auth_lti.middleware_patched.auth')
+    @patch('django_auth_lti.middleware_patched.set_current_request')
+    def test_lti_max_launches(self, mock_set_current_request, mock_auth, mock_logger):
+        """
+        Asserts the constraint for maximum number of LTI launches.
+        """
+        mock_auth.authenticate.return_value = True
+
+        session = dict()
+        for i in range(LTI_AUTH_MAX_LAUNCHES + 2):
+            launch_num = i + 1
+            resource_link_id = 'a312fb112a14f9' + str(i)
+            request = self.build_lti_launch_request({"resource_link_id": resource_link_id})
+            request.session = session
+            self.mw.process_request(request)
+            self.assertIsInstance(request.session['LTI_LAUNCH'], OrderedDict)
+
+            actual_launch_count = len(request.session['LTI_LAUNCH'].keys())
+            expected_launch_count = launch_num
+            if launch_num >= LTI_AUTH_MAX_LAUNCHES:
+                expected_launch_count = LTI_AUTH_MAX_LAUNCHES
+
+            self.assertTrue(expected_launch_count, actual_launch_count)
+
+    @patch('django_auth_lti.middleware_patched.auth')
+    def test_old_lti_launch_session_dict(self, mock_auth, mock_logger):
+        mock_auth.authenticate.return_value = True
+        request = self.build_lti_launch_request({})
+        lti_launch = {"custom_foo": "bar"}
+        request.session = dict(LTI_LAUNCH=lti_launch)
+        self.mw.process_request(request)
+        self.assertIsInstance(request.session['LTI_LAUNCH'], OrderedDict)
+
+        #or not isinstance(lti_launches, OrderedDict)


### PR DESCRIPTION
This PR resolves a `TypeError` when transitioning from `django_auth_lti.middlware` to `django_auth_lti.middlware_patched`. Tools that still have sessions stored as a dict rather than OrderedDict will raise an error when it comes time to invalidate a launch:

```python
invalidated_launch = lti_launches.popitem(last=False)
```

The proposed fix is to just invalidate the old session and replace it with a new `OrderedDict`. 

@bermudezjd @cmurtaugh @sapnamysore  Thoughts?

